### PR TITLE
Adjusting JJB setup to work with RedHat nodes

### DIFF
--- a/rpc-qe-jobs/jjb-setup.yml
+++ b/rpc-qe-jobs/jjb-setup.yml
@@ -12,11 +12,17 @@
         - bool:
             name: IGNORE_CACHE
             description: "Ignore cache when updating jobs."
+        - string:
+            name: JJB_REPO
+            default: https://github.com/rcbops-qe/jenkins-jobs
+        - string:
+            name: JJB_BRANCH
+            default: master
     scm:
         - git:
-            url: https://github.com/rcbops-qe/jenkins-jobs
+            url: $JJB_REPO
             branches:
-                - "*/master"
+                - $JJB_BRANCH
             skip-tag: true
             wipe-workspace: false
     builders:

--- a/rpc-qe-jobs/jjb-setup.yml
+++ b/rpc-qe-jobs/jjb-setup.yml
@@ -20,17 +20,20 @@
             skip-tag: true
             wipe-workspace: false
     builders:
-        - shining-panda:
-            build-environment: virtualenv
-            python-version: System-CPython-2.7
-            nature: shell
-            command: |
-                rm -rf jenkins-job-builder
-                git clone https://github.com/openstack-infra/jenkins-job-builder
-                pip install ./jenkins-job-builder
+        - shell: |
+            #Setup virtual env for the project to build in
+            pip install virtualenv
 
-                if [ "$IGNORE_CACHE" = "true" ]; then
-                    JJB_ARGS="--ignore-cache"
-                fi
+            if [[ ! -d ".venv" ]]; then
+                scl enable python27 bash
+                virtualenv -p /opt/rh/python27/root/usr/bin/python .venv
+            fi
+            source .venv/bin/activate
 
-                jenkins-jobs --conf ~/jenkins_jobs.ini $JJB_ARGS update $JOBS
+            pip install jenkins-job-builder
+
+            if [ "$IGNORE_CACHE" = "true" ]; then
+                JJB_ARGS="--ignore-cache"
+            fi
+
+            jenkins-jobs --conf ~/jenkins_jobs.ini $JJB_ARGS update $JOBS


### PR DESCRIPTION
Changed from using the ShiningPanda virtualenv builder to a normal shell script since the plugin still isn't  recognizing the Python 2.7. This was the only job with that plugin in anyway, so it'll be good to keep it consistent.

Connects rcbops/u-suk-dev#960